### PR TITLE
Add additional roles for Monad main Discord

### DIFF
--- a/packages/nextjs/components/scaffold-eth/DiscordRoles.tsx
+++ b/packages/nextjs/components/scaffold-eth/DiscordRoles.tsx
@@ -28,6 +28,16 @@ const MONAD_SERVER_ROLES: Record<string, string> = {
   "1051562453495971941": "nads",
   "1194003002298740816": "localnads",
   "1072682201658970112": "full access",
+  "1234915103267094528": "IRL",
+  "1225505808058548295": "TG⨀",
+  "1151563303827554334": "monartist",
+  "1050582402776436756": "1)what",
+  "1217522152497086524": "pipeline intern",
+  "1037205170397904956": "pioneer",
+  "1085044350939050075": "Running Hot",
+  "1169411756972593253": "monvideo",
+  "1195097123599962193": "yaps",
+
 };
 
 const MONAD_DEV_ROLES: Record<string, string> = {


### PR DESCRIPTION

## Description

Added the following roles:
  "1234915103267094528": "IRL",
  "1225505808058548295": "TG⨀",
  "1151563303827554334": "monartist",
  "1050582402776436756": "1)what",
  "1217522152497086524": "pipeline intern",
  "1037205170397904956": "pioneer",
  "1085044350939050075": "Running Hot",
  "1169411756972593253": "monvideo",
  "1195097123599962193": "yaps",

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #1 _

Your ENS/address:
nicomenzi.eth